### PR TITLE
add rem fallback + documentation

### DIFF
--- a/public/app/sass/main.scss
+++ b/public/app/sass/main.scss
@@ -4,6 +4,7 @@
 //modules
 @import 'modules/breakpoints';
 @import 'modules/colors';
+@import 'modules/rem';
 
 //dev
 @import 'dev/example-colors';

--- a/public/app/sass/modules/rem.scss
+++ b/public/app/sass/modules/rem.scss
@@ -1,0 +1,16 @@
+/*
+REM Fallback
+============
+The `@include rem($property, $value)` mixin automatically creates a rem fallback, assuming a base font size of 16px.
+    <p>This</p>
+    <code>@include rem('width', 2);</code>
+    <p>Compiles to..</p>
+    <code class="test">width: 32px;
+    <br>
+    width: 2rem;</code>
+*/
+
+@mixin rem($property, $value) {
+  #{$property}: $value*16px;
+  #{$property}: $value*1rem;
+}


### PR DESCRIPTION
# REM Fallback

The `@include rem($property, $value)` mixin automatically creates a rem fallback, assuming a base font size of 16px.
`@include rem('width', 2);` compiles to `width: 32px; width: 2rem;`
