### PR TITLE
Rem fallback

### DIFF
--- a/public/app/sass/modules/rem.scss
+++ b/public/app/sass/modules/rem.scss
@@ -5,7 +5,7 @@ The `@include rem($property, $value)` mixin automatically creates a rem fallback
     <p>This</p>
     <code>@include rem('width', 2);</code>
     <p>Compiles to..</p>
-    <code class="test">width: 32px;
+    <code>width: 32px;
     <br>
     width: 2rem;</code>
 */

--- a/public/app/sass/modules/rem.scss
+++ b/public/app/sass/modules/rem.scss
@@ -14,3 +14,11 @@ The `@include rem($property, $value)` mixin automatically creates a rem fallback
   #{$property}: $value*16px;
   #{$property}: $value*1rem;
 }
+
+@function to-px($value) {
+  @return $rem-value*1px;
+}
+
+@function to-rem($value) {
+  @return $px-value*1rem;
+}


### PR DESCRIPTION
Added the `to-px` and `to-em` functions that enable developers to manually translate rem to px and vice versa.
